### PR TITLE
littlecheck: pass close_fds to subprocess.Popen

### DIFF
--- a/littlecheck/littlecheck.py
+++ b/littlecheck/littlecheck.py
@@ -250,7 +250,12 @@ class TestRun(object):
         if self.config.verbose:
             print(self.subbed_command)
         proc = subprocess.Popen(
-            self.subbed_command, stdin=PIPE, stdout=PIPE, stderr=PIPE, shell=True
+            self.subbed_command,
+            stdin=PIPE,
+            stdout=PIPE,
+            stderr=PIPE,
+            shell=True,
+            close_fds=True,  # For Python 2.6 as shipped on RHEL 6
         )
         stdout, stderr = proc.communicate()
         outlines = [


### PR DESCRIPTION
Found with fish-shell/fish-shell#6435.

`close_fds=True` is actually the default in Python 2.7 and 3.2, but not in ancient (but still in production in Red Hat Enterprise Linux 6) Python2.6. Enable it there as well.