### PR TITLE
Add context display

### DIFF
--- a/littlecheck/littlecheck.py
+++ b/littlecheck/littlecheck.py
@@ -34,6 +34,8 @@ class Config(object):
         self.progress = False
         # How many after lines to print
         self.after = 5
+        # How many before lines to print
+        self.before = 5
 
     def colors(self):
         """ Return a dictionary mapping color names to ANSI escapes """
@@ -236,8 +238,7 @@ class TestRun(object):
         lineq = lines[::-1]
         checkq = checks[::-1]
         # We keep the last couple of lines in a deque so we can show context.
-        # For now the maximum length is not configurable.
-        before = deque(maxlen=5)
+        before = deque(maxlen = self.config.before)
         while lineq and checkq:
             line = lineq[-1]
             check = checkq[-1]
@@ -472,6 +473,14 @@ def get_argparse():
         action="store",
         default=5,
     )
+    parser.add_argument(
+        "-B",
+        "--before",
+        type=int,
+        help="How many non-empty lines of output before a failure to print (default: 5)",
+        action="store",
+        default=5,
+    )
     return parser
 
 
@@ -487,6 +496,10 @@ def main():
     config.progress = args.progress
     fields = config.colors()
     config.after = args.after
+    config.before = args.before
+    if config.before < 0:
+        raise ValueError("Before must be at least 0")
+
     for path in args.file:
         fields["path"] = path
         if config.progress:

--- a/littlecheck/littlecheck.py
+++ b/littlecheck/littlecheck.py
@@ -188,7 +188,7 @@ class TestFailure(object):
         if self.before:
             fields["before_output"] = "    ".join(self.before)
             fields["additional_output"] = "    ".join(self.after[:afterlines])
-            fmtstrs += [" Context:",
+            fmtstrs += ["  Context:",
                         "    {BOLD}{before_output}    {RED}{output_line}{RESET} <= does not match '{LIGHTBLUE}{input_line}{RESET}'",
                         "    {BOLD}{additional_output}{RESET}"]
         elif self.after:

--- a/littlecheck/littlecheck.py
+++ b/littlecheck/littlecheck.py
@@ -499,6 +499,8 @@ def main():
     config.before = args.before
     if config.before < 0:
         raise ValueError("Before must be at least 0")
+    if config.after < 0:
+        raise ValueError("After must be at least 0")
 
     for path in args.file:
         fields["path"] = path

--- a/test/files/python_middle_error.expected
+++ b/test/files/python_middle_error.expected
@@ -6,7 +6,7 @@ Failure in python_middle_error.py:
   which failed to match line stderr:3:
     GAMMA3
 
- Context:
+  Context:
     GAMMA1
     GAMMA2
     GAMMA3 <= does not match 'BETA'

--- a/test/files/python_middle_error.expected
+++ b/test/files/python_middle_error.expected
@@ -1,0 +1,20 @@
+Failure in python_middle_error.py:
+
+  The CHECKERR on line 10 wants:
+    BETA
+
+  which failed to match line stderr:3:
+    GAMMA3
+
+ Context:
+    GAMMA1
+    GAMMA2
+    GAMMA3 <= does not match 'BETA'
+    GAMMA4
+    GAMMA5
+    GAMMA6
+    GAMMA7
+    GAMMA8
+
+  when running command:
+    /usr/bin/python python_middle_error.py

--- a/test/files/python_middle_error.py
+++ b/test/files/python_middle_error.py
@@ -1,0 +1,20 @@
+# RUN: /usr/bin/python %s
+
+import sys
+
+sys.stderr.write("GAMMA1\n")
+# CHECKERR: GAMMA1
+sys.stderr.write("GAMMA2\n")
+# CHECKERR: GAMMA2
+sys.stderr.write("GAMMA3\n")
+# CHECKERR: BETA
+sys.stderr.write("GAMMA4\n")
+# CHECKERR: GAMMA4
+sys.stderr.write("GAMMA5\n")
+# CHECKERR: GAMMA5
+sys.stderr.write("GAMMA6\n")
+# CHECKERR: GAMMA6
+sys.stderr.write("GAMMA7\n")
+# CHECKERR: GAMMA7
+sys.stderr.write("GAMMA8\n")
+# CHECKERR: GAMMA8

--- a/test/files/python_out_vs_err.expected
+++ b/test/files/python_out_vs_err.expected
@@ -9,7 +9,7 @@ Failure in python_out_vs_err.py:
   additional output on stderr:1:
     something failed
 
- Context:
+  Context:
     fine so far
     now stdout is broken <= does not match 'things should be cool'
     

--- a/test/files/python_out_vs_err.expected
+++ b/test/files/python_out_vs_err.expected
@@ -9,5 +9,9 @@ Failure in python_out_vs_err.py:
   additional output on stderr:1:
     something failed
 
+ Context:
+    fine so far
+    now stdout is broken <= does not match 'things should be cool'
+    
   when running command:
     /usr/bin/python python_out_vs_err.py

--- a/test/test_littlecheck.py
+++ b/test/test_littlecheck.py
@@ -37,6 +37,9 @@ class LittlecheckTest(unittest.TestCase):
     def test_py_err1(self):
         self.do_1_path_test("python_err1")
 
+    def test_py_middle_error(self):
+        self.do_1_path_test("python_middle_error")
+
     def test_py_missing_output(self):
         self.do_1_path_test("python_missing_output")
 


### PR DESCRIPTION
This keeps the last 5 (non-configurable, for now) lines in a buffer
and displays them, together with the failing line, the failing input
and the "after" lines.

It looks like this:

![Screenshot_20200328_142247](https://user-images.githubusercontent.com/5185367/77824095-3ae13d80-7100-11ea-854f-5ab183fff893.png)

I feel like this is a large boon for error readability, especially in cases like the above where fish has a load of tests that just print "0" or "1" in succession (they used to have "catch your breath" comment-output so you stood a *chance* of figuring it out)