### PR TITLE
Diff output

### DIFF
--- a/littlecheck/littlecheck.py
+++ b/littlecheck/littlecheck.py
@@ -156,14 +156,12 @@ class RunCmd(object):
 
 
 class TestFailure(object):
-    def __init__(self, line, check, testrun, diff=None, text1=[], text2=[], lines=[], checks=[]):
+    def __init__(self, line, check, testrun, diff=None, lines=[], checks=[]):
         self.line = line
         self.check = check
         self.testrun = testrun
         self.error_annotation_lines = None
         self.diff = diff
-        self.text1 = text1
-        self.text2 = text2
         self.lines = lines
         self.checks = checks
 
@@ -345,11 +343,11 @@ class TestRun(object):
         # If there's a mismatch or still lines or checkers, we have a failure.
         # Otherwise it's success.
         if mismatches:
-            return TestFailure(mismatches[0][0], mismatches[0][1], self, diff=diff, text1=text1, text2=text2, lines=usedlines, checks=usedchecks)
+            return TestFailure(mismatches[0][0], mismatches[0][1], self, diff=diff, lines=usedlines, checks=usedchecks)
         elif lineq:
-            return TestFailure(lineq[-1], None, self, diff=diff, text1=text1, text2=text2, lines=usedlines, checks=usedchecks)
+            return TestFailure(lineq[-1], None, self, diff=diff, lines=usedlines, checks=usedchecks)
         elif checkq:
-            return TestFailure(None, checkq[-1], self, diff=diff, text1=text1, text2=text2, lines=usedlines, checks=usedchecks)
+            return TestFailure(None, checkq[-1], self, diff=diff, lines=usedlines, checks=usedchecks)
         else:
             # Success!
             return None

--- a/littlecheck/littlecheck.py
+++ b/littlecheck/littlecheck.py
@@ -239,17 +239,17 @@ class TestFailure(object):
                         ]
                     lasthi = ahi
 
-                    for a, b in zip_longest(self.text1[alo:ahi], self.text2[blo:bhi]):
+                    for a, b in zip_longest(self.lines[alo:ahi], self.checks[blo:bhi]):
                         # Clean up strings for use in a format string - double up the curlies.
-                        astr = color + a.replace("{", "{{").replace("}", "}}") + "{RESET}" if a else ""
-                        if b: b = b.replace("{", "{{").replace("}", "}}")
+                        astr = color + a.escaped_text().replace("{", "{{").replace("}", "}}") + "{RESET}" if a else ""
+                        if b: bstr = "'{BLUE}" + b.line.escaped_text().replace("{", "{{").replace("}", "}}") + "{RESET}'" + " on line " + str(b.line.number)
 
                         if op == 'equal':
                             fmtstrs += ["    " + astr]
                         elif b and a:
-                            fmtstrs += ["    " + astr + " <= does not match '{BLUE}" + b + "{RESET}'"]
+                            fmtstrs += ["    " + astr + " <= does not match " + bstr]
                         elif b:
-                            fmtstrs += ["    " + astr + " <= nothing to match '{BLUE}" + b + "{RESET}'"]
+                            fmtstrs += ["    " + astr + " <= nothing to match " + bstr]
                         elif not b:
                             string = "    " + astr
                             string += " (nothing to match)"

--- a/littlecheck/littlecheck.py
+++ b/littlecheck/littlecheck.py
@@ -132,6 +132,9 @@ class Line(object):
     def is_empty_space(self):
         return not self.text or self.text.isspace()
 
+    def escaped_text(self):
+        return escape_string(self.text.rstrip("\n"))
+
 
 class RunCmd(object):
     """ A command to run on a given Checker.
@@ -171,7 +174,7 @@ class TestFailure(object):
                 {
                     "output_file": self.line.file,
                     "output_lineno": self.line.number,
-                    "output_line": self.line.text.rstrip("\n"),
+                    "output_line": self.line.escaped_text(),
                 }
             )
         if self.check:
@@ -179,7 +182,7 @@ class TestFailure(object):
                 {
                     "input_file": self.check.line.file,
                     "input_lineno": self.check.line.number,
-                    "input_line": self.check.line.text,
+                    "input_line": self.check.line.escaped_text(),
                     "check_type": self.check.type,
                 }
             )
@@ -291,15 +294,15 @@ class TestRun(object):
             else:
                 # Failed to match.
                 lineq.pop()
-                line.text = escape_string(line.text.strip()) + "\n"
+                line.text = line.escaped_text() + "\n"
                 # Add context, ignoring empty lines.
                 return TestFailure(
                     line,
                     check,
                     self,
-                    before=[escape_string(line.text.strip()) + "\n" for line in before],
+                    before=[line.escaped_text() + "\n" for line in before],
                     after=[
-                        escape_string(line.text.strip()) + "\n"
+                        line.escaped_text() + "\n"
                         for line in lineq[::-1]
                         if not line.is_empty_space()
                     ],

--- a/littlecheck/littlecheck.py
+++ b/littlecheck/littlecheck.py
@@ -259,12 +259,12 @@ class TestFailure(object):
                             string = "    " + astr
                             if bhi == len(self.checks):
                                 if not lastcheck:
-                                    string += " (no more checks)"
+                                    string += " <= no more checks"
                                     lastcheck = True
                             elif lastcheckline is not None:
-                                string += " (nothing to match, previous check on line " + str(lastcheckline) + ")"
+                                string += " <= nothing to match, previous check on line " + str(lastcheckline)
                             else:
-                                string += " (nothing to match, no previous check)"
+                                string += " <= nothing to match, no previous check"
                             fmtstrs.append(string)
             fmtstrs.append("")
         fmtstrs += ["  when running command:", "    {subbed_command}"]

--- a/littlecheck/littlecheck.py
+++ b/littlecheck/littlecheck.py
@@ -13,6 +13,8 @@ import re
 import shlex
 import subprocess
 import sys
+from itertools import zip_longest
+from difflib import SequenceMatcher
 
 # Directives can occur at the beginning of a line, or anywhere in a line that does not start with #.
 COMMENT_RE = r'^(?:[^#].*)?#\s*'
@@ -151,11 +153,16 @@ class RunCmd(object):
 
 
 class TestFailure(object):
-    def __init__(self, line, check, testrun):
+    def __init__(self, line, check, testrun, diff=None, text1=[], text2=[], lines=[], checks=[]):
         self.line = line
         self.check = check
         self.testrun = testrun
         self.error_annotation_lines = None
+        self.diff = diff
+        self.text1 = text1
+        self.text2 = text2
+        self.lines = lines
+        self.checks = checks
 
     def message(self):
         fields = self.testrun.config.colors()
@@ -213,6 +220,38 @@ class TestFailure(object):
                 "  additional output on stderr:{error_annotation_lineno}:",
                 "    {BOLD}{error_annotation}{RESET}",
             ]
+        if self.diff:
+            fmtstrs += ["  Context:"]
+            lasthi = 0
+            for d in self.diff.get_grouped_opcodes():
+                for op, alo, ahi, blo, bhi in d:
+                    color="{BOLD}"
+                    if op == 'replace' or op == 'delete':
+                        color="{RED}"
+                    # We got a new chunk, so we print a marker.
+                    if alo > lasthi:
+                        fmtstrs += [
+                            "    [...] from line " + str(self.checks[blo].line.number)
+                            + " " + self.lines[alo].file + ":" + str(self.lines[alo].number)
+                        ]
+                    lasthi = ahi
+
+                    for a, b in zip_longest(self.text1[alo:ahi], self.text2[blo:bhi]):
+                        # Clean up strings for use in a format string - double up the curlies.
+                        astr = color + a.replace("{", "{{").replace("}", "}}") + "{RESET}" if a else ""
+                        if b: b = b.replace("{", "{{").replace("}", "}}")
+
+                        if op == 'equal':
+                            fmtstrs += ["    " + astr]
+                        elif b and a:
+                            fmtstrs += ["    " + astr + " <= does not match '{BLUE}" + b + "{RESET}'"]
+                        elif b:
+                            fmtstrs += ["    " + astr + " <= nothing to match '{BLUE}" + b + "{RESET}'"]
+                        elif not b:
+                            string = "    " + astr
+                            string += " (nothing to match)"
+                            fmtstrs.append(string)
+            fmtstrs.append("")
         fmtstrs += ["  when running command:", "    {subbed_command}"]
         return "\n".join(fmtstrs).format(**fields)
 
@@ -256,36 +295,60 @@ class TestRun(object):
         # Reverse our lines and checks so we can pop off the end.
         lineq = lines[::-1]
         checkq = checks[::-1]
+        usedlines = []
+        usedchecks = []
+        text1 = []
+        text2 = []
+        mismatches = []
         while lineq and checkq:
             line = lineq[-1]
             check = checkq[-1]
             if check.regex.match(line.text):
                 # This line matched this checker, continue on.
+                text1.append(line.escaped_text())
+                usedlines.append(line)
+                text2.append(line.escaped_text())
+                usedchecks.append(check)
                 lineq.pop()
                 checkq.pop()
             elif line.is_empty_space():
                 # Skip all whitespace input lines.
                 lineq.pop()
             else:
+                text1.append(line.escaped_text())
+                usedlines.append(line)
+                text2.append(check.line.escaped_text())
+                usedchecks.append(check)
+                mismatches.append((line, check))
                 # Failed to match.
                 lineq.pop()
-                line.text = line.escaped_text() + "\n"
-                # Add context, ignoring empty lines.
-                return TestFailure(
-                    line,
-                    check,
-                    self,
-                )
-        # Drain empties.
+                checkq.pop()
+
+        # Drain empties
         while lineq and lineq[-1].is_empty_space():
             lineq.pop()
-        # If there's still lines or checkers, we have a failure.
+
+        # Store the remaining lines for the diff
+        for i in lineq[::-1]:
+            if not i.is_empty_space():
+                text1.append(i.escaped_text())
+                usedlines.append(i)
+        # Store remaining checks for the diff
+        for i in checkq[::-1]:
+            text2.append(i.line.escaped_text())
+
+        # Do a SequenceMatch! This gives us a diff-like thing.
+        diff = SequenceMatcher(a=text1, b=text2)
+        # If there's a mismatch or still lines or checkers, we have a failure.
         # Otherwise it's success.
-        if lineq:
-            return TestFailure(lineq[-1], None, self)
+        if mismatches:
+            return TestFailure(mismatches[0][0], mismatches[0][1], self, diff=diff, text1=text1, text2=text2, lines=usedlines, checks=usedchecks)
+        elif lineq:
+            return TestFailure(lineq[-1], None, self, diff=diff, text1=text1, text2=text2, lines=usedlines, checks=usedchecks)
         elif checkq:
-            return TestFailure(None, checkq[-1], self)
+            return TestFailure(None, checkq[-1], self, diff=diff, text1=text1, text2=text2, lines=usedlines, checks=usedchecks)
         else:
+            # Success!
             return None
 
     def run(self):

--- a/littlecheck/littlecheck.py
+++ b/littlecheck/littlecheck.py
@@ -226,6 +226,7 @@ class TestFailure(object):
         if self.diff:
             fmtstrs += ["  Context:"]
             lasthi = 0
+            lastcheckline = None
             for d in self.diff.get_grouped_opcodes():
                 for op, alo, ahi, blo, bhi in d:
                     color="{BOLD}"
@@ -242,7 +243,9 @@ class TestFailure(object):
                     for a, b in zip_longest(self.lines[alo:ahi], self.checks[blo:bhi]):
                         # Clean up strings for use in a format string - double up the curlies.
                         astr = color + a.escaped_text(for_formatting=True) + "{RESET}" if a else ""
-                        if b: bstr = "'{BLUE}" + b.line.escaped_text(for_formatting=True) + "{RESET}'" + " on line " + str(b.line.number)
+                        if b:
+                            bstr = "'{BLUE}" + b.line.escaped_text(for_formatting=True) + "{RESET}'" + " on line " + str(b.line.number)
+                            lastcheckline = b.line.number
 
                         if op == 'equal':
                             fmtstrs += ["    " + astr]
@@ -252,7 +255,10 @@ class TestFailure(object):
                             fmtstrs += ["    " + astr + " <= nothing to match " + b.type + " " + bstr]
                         elif not b:
                             string = "    " + astr
-                            string += " (nothing to match)"
+                            if lastcheckline is not None:
+                                string += " (nothing to match, previous check on line " + str(lastcheckline) + ")"
+                            else:
+                                string += " (nothing to match, no previous check)"
                             fmtstrs.append(string)
             fmtstrs.append("")
         fmtstrs += ["  when running command:", "    {subbed_command}"]

--- a/littlecheck/littlecheck.py
+++ b/littlecheck/littlecheck.py
@@ -133,9 +133,11 @@ class Line(object):
     def is_empty_space(self):
         return not self.text or self.text.isspace()
 
-    def escaped_text(self):
-        return escape_string(self.text.rstrip("\n"))
-
+    def escaped_text(self, for_formatting=False):
+        ret = escape_string(self.text.rstrip("\n"))
+        if for_formatting:
+            ret = ret.replace("{", "{{").replace("}", "}}")
+        return ret
 
 class RunCmd(object):
     """ A command to run on a given Checker.
@@ -239,8 +241,8 @@ class TestFailure(object):
 
                     for a, b in zip_longest(self.lines[alo:ahi], self.checks[blo:bhi]):
                         # Clean up strings for use in a format string - double up the curlies.
-                        astr = color + a.escaped_text().replace("{", "{{").replace("}", "}}") + "{RESET}" if a else ""
-                        if b: bstr = "'{BLUE}" + b.line.escaped_text().replace("{", "{{").replace("}", "}}") + "{RESET}'" + " on line " + str(b.line.number)
+                        astr = color + a.escaped_text(for_formatting=True) + "{RESET}" if a else ""
+                        if b: bstr = "'{BLUE}" + b.line.escaped_text(for_formatting=True) + "{RESET}'" + " on line " + str(b.line.number)
 
                         if op == 'equal':
                             fmtstrs += ["    " + astr]

--- a/littlecheck/littlecheck.py
+++ b/littlecheck/littlecheck.py
@@ -240,6 +240,8 @@ class TestFailure(object):
                         ]
                     lasthi = ahi
 
+                    # We print one "no more checks" after the last check and then skip any markers
+                    lastcheck = False
                     for a, b in zip_longest(self.lines[alo:ahi], self.checks[blo:bhi]):
                         # Clean up strings for use in a format string - double up the curlies.
                         astr = color + a.escaped_text(for_formatting=True) + "{RESET}" if a else ""
@@ -255,7 +257,11 @@ class TestFailure(object):
                             fmtstrs += ["    " + astr + " <= nothing to match " + b.type + " " + bstr]
                         elif not b:
                             string = "    " + astr
-                            if lastcheckline is not None:
+                            if bhi == len(self.checks):
+                                if not lastcheck:
+                                    string += " (no more checks)"
+                                    lastcheck = True
+                            elif lastcheckline is not None:
                                 string += " (nothing to match, previous check on line " + str(lastcheckline) + ")"
                             else:
                                 string += " (nothing to match, no previous check)"

--- a/littlecheck/littlecheck.py
+++ b/littlecheck/littlecheck.py
@@ -318,7 +318,17 @@ class TestRun(object):
             else:
                 text1.append(line.escaped_text())
                 usedlines.append(line)
-                text2.append(check.line.escaped_text())
+                # HACK: Theoretically it's possible that
+                # the line is the same as the CHECK regex but doesn't match
+                # (e.g. both are `\s+` or something).
+                # Since we only need this for the SequenceMatcher to *compare*,
+                # we give it a fake non-matching check in those cases.
+                etext = check.line.escaped_text()
+                if etext != line.escaped_text():
+                    text2.append(etext)
+                else:
+                    text2.append(" " + etext)
+
                 usedchecks.append(check)
                 mismatches.append((line, check))
                 # Failed to match.

--- a/littlecheck/littlecheck.py
+++ b/littlecheck/littlecheck.py
@@ -13,7 +13,10 @@ import re
 import shlex
 import subprocess
 import sys
-from itertools import zip_longest
+try:
+    from itertools import zip_longest
+except ImportError:
+    from itertools import izip_longest as zip_longest
 from difflib import SequenceMatcher
 
 # Directives can occur at the beginning of a line, or anywhere in a line that does not start with #.

--- a/littlecheck/littlecheck.py
+++ b/littlecheck/littlecheck.py
@@ -236,7 +236,7 @@ class TestFailure(object):
                     if alo > lasthi:
                         fmtstrs += [
                             "    [...] from line " + str(self.checks[blo].line.number)
-                            + " " + self.lines[alo].file + ":" + str(self.lines[alo].number)
+                            + " (" + self.lines[alo].file + ":" + str(self.lines[alo].number) + ")"
                         ]
                     lasthi = ahi
 

--- a/littlecheck/littlecheck.py
+++ b/littlecheck/littlecheck.py
@@ -262,9 +262,9 @@ class TestFailure(object):
                                     string += " <= no more checks"
                                     lastcheck = True
                             elif lastcheckline is not None:
-                                string += " <= nothing to match, previous check on line " + str(lastcheckline)
+                                string += " <= no check matches this, previous check on line " + str(lastcheckline)
                             else:
-                                string += " <= nothing to match, no previous check"
+                                string += " <= no check matches"
                             fmtstrs.append(string)
             fmtstrs.append("")
         fmtstrs += ["  when running command:", "    {subbed_command}"]

--- a/littlecheck/littlecheck.py
+++ b/littlecheck/littlecheck.py
@@ -247,9 +247,9 @@ class TestFailure(object):
                         if op == 'equal':
                             fmtstrs += ["    " + astr]
                         elif b and a:
-                            fmtstrs += ["    " + astr + " <= does not match " + bstr]
+                            fmtstrs += ["    " + astr + " <= does not match " + b.type + " " + bstr]
                         elif b:
-                            fmtstrs += ["    " + astr + " <= nothing to match " + bstr]
+                            fmtstrs += ["    " + astr + " <= nothing to match " + b.type + " " + bstr]
                         elif not b:
                             string = "    " + astr
                             string += " (nothing to match)"

--- a/littlecheck/littlecheck.py
+++ b/littlecheck/littlecheck.py
@@ -347,6 +347,7 @@ class TestRun(object):
         # Store remaining checks for the diff
         for i in checkq[::-1]:
             text2.append(i.line.escaped_text())
+            usedchecks.append(i)
 
         # Do a SequenceMatch! This gives us a diff-like thing.
         diff = SequenceMatcher(a=text1, b=text2)

--- a/test/files/inline-check.expected
+++ b/test/files/inline-check.expected
@@ -9,7 +9,6 @@ Failure in inline-check.py:
   Context:
     ok
     mismatch <= does not match 'match'
-    
+
   when running command:
     /bin/sh inline-check.py
-

--- a/test/files/python_color.expected
+++ b/test/files/python_color.expected
@@ -6,5 +6,8 @@ Failure in python_color.py:
   which failed to match line stdout:1:
     \x1b[33mFOO
 
+  Context:
+    \x1b[33mFOO <= does not match 'banana'
+
   when running command:
     /usr/bin/python python_color.py

--- a/test/files/python_err1.expected
+++ b/test/files/python_err1.expected
@@ -8,11 +8,14 @@ Failure in python_err1.py:
 
   Context:
     ALPHA <= does not match 'BETA'
-    GAMMA1
-    GAMMA2
-    GAMMA3
-    GAMMA4
-    GAMMA5
+    GAMMA1 (nothing to match)
+    GAMMA2 (nothing to match)
+    GAMMA3 (nothing to match)
+    GAMMA4 (nothing to match)
+    GAMMA5 (nothing to match)
+    GAMMA6 (nothing to match)
+    GAMMA7 (nothing to match)
+    GAMMA8 (nothing to match)
 
   when running command:
     /usr/bin/python python_err1.py

--- a/test/files/python_extra_output.expected
+++ b/test/files/python_extra_output.expected
@@ -3,5 +3,9 @@ Failure in python_extra_output.py:
   There were no remaining checks left to match stdout:2:
     Second
 
+  Context:
+    First
+    Second (nothing to match)
+
   when running command:
     /usr/bin/python python_extra_output.py

--- a/test/files/python_middle_error.expected
+++ b/test/files/python_middle_error.expected
@@ -13,8 +13,6 @@ Failure in python_middle_error.py:
     GAMMA4
     GAMMA5
     GAMMA6
-    GAMMA7
-    GAMMA8
 
   when running command:
     /usr/bin/python python_middle_error.py

--- a/test/files/python_missing_check.expected
+++ b/test/files/python_missing_check.expected
@@ -1,0 +1,22 @@
+Failure in python_missing_check.py:
+
+  The CHECKERR on line 7 wants:
+    BETA
+
+  which failed to match line stderr:1:
+    ALPHA
+
+  Context:
+    ALPHA (nothing to match)
+    BETA
+    GAMMA1 (nothing to match)
+    GAMMA2 (nothing to match)
+    GAMMA3 (nothing to match)
+    GAMMA4 (nothing to match)
+    GAMMA5 (nothing to match)
+    GAMMA6 (nothing to match)
+    GAMMA7 (nothing to match)
+    GAMMA8 (nothing to match)
+
+  when running command:
+    /usr/bin/python python_missing_check.py

--- a/test/files/python_missing_check.py
+++ b/test/files/python_missing_check.py
@@ -1,0 +1,17 @@
+# RUN: /usr/bin/python %s
+
+import sys
+
+sys.stderr.write("ALPHA\n")
+sys.stderr.write("BETA\n")
+# CHECKERR: BETA
+
+# Some superfluous output so we can test --after.
+sys.stderr.write("GAMMA1\n")
+sys.stderr.write("GAMMA2\n")
+sys.stderr.write("GAMMA3\n")
+sys.stderr.write("GAMMA4\n")
+sys.stderr.write("GAMMA5\n")
+sys.stderr.write("GAMMA6\n")
+sys.stderr.write("GAMMA7\n")
+sys.stderr.write("GAMMA8\n")

--- a/test/files/python_missing_output.expected
+++ b/test/files/python_missing_output.expected
@@ -3,7 +3,23 @@ Failure in python_missing_output.py:
   The CHECK on line 8 wants:
     NotPrinted
 
-  but there was no remaining output to match.
+  which failed to match line stdout:2:
+    Second
+
+  Context:
+    First
+     <= nothing to match 'NotPrinted'
+    Second
+    Third
+    1 (nothing to match)
+    2
+    3
+    4
+    [...] from line 34 stdout:14
+    6
+    6
+    6
+    Fourth <= does not match '{{\\d}}'
 
   when running command:
     /usr/bin/python python_missing_output.py

--- a/test/files/python_missing_output.py
+++ b/test/files/python_missing_output.py
@@ -6,3 +6,37 @@ print("First")
 # CHECK: First
 
 # CHECK: NotPrinted
+
+print("Second")
+# CHECK: Second
+print("Third")
+# CHECK: Third
+
+print("1")
+# CHECK: {{\d}}
+print("2")
+# CHECK: {{\d}}
+print("3")
+# CHECK: {{\d}}
+print("4")
+# CHECK: {{\d}}
+print("5")
+# CHECK: {{\d}}
+print("6")
+# CHECK: {{\d}}
+print("6")
+# CHECK: {{\d}}
+print("6")
+# CHECK: {{\d}}
+print("6")
+# CHECK: {{\d}}
+print("6")
+# CHECK: {{\d}}
+print("6")
+# CHECK: {{\d}}
+print("6")
+# CHECK: {{\d}}
+print("6")
+# CHECK: {{\d}}
+
+print("Fourth")

--- a/test/files/python_multipe_error_annotation_lines.expected
+++ b/test/files/python_multipe_error_annotation_lines.expected
@@ -14,7 +14,7 @@ Failure in python_multipe_error_annotation_lines.py:
   Context:
     fine so far
     something failed <= does not match 'things should be cool'
-    now stdout is broken
+    now stdout is broken (nothing to match)
 
   when running command:
     /usr/bin/python python_multipe_error_annotation_lines.py

--- a/test/files/python_multiple_errors.expected
+++ b/test/files/python_multiple_errors.expected
@@ -1,0 +1,16 @@
+Failure in python_multiple_errors.py:
+
+  The CHECK on line 7 wants:
+    eins
+
+  which failed to match line stdout:2:
+    one
+
+  Context:
+    foo
+    one <= does not match 'eins'
+    two <= does not match 'zwei'
+    bar
+
+  when running command:
+    /usr/bin/python python_multiple_errors.py

--- a/test/files/python_multiple_errors.py
+++ b/test/files/python_multiple_errors.py
@@ -1,0 +1,11 @@
+# RUN: /usr/bin/python %s
+import sys
+
+sys.stdout.write("foo\n")
+# CHECK: foo
+sys.stdout.write("one\n")
+# CHECK: eins
+sys.stdout.write("two\n")
+# CHECK: zwei
+sys.stdout.write("bar\n")
+# CHECK: bar

--- a/test/files/python_out_vs_err.expected
+++ b/test/files/python_out_vs_err.expected
@@ -12,6 +12,6 @@ Failure in python_out_vs_err.py:
   Context:
     fine so far
     now stdout is broken <= does not match 'things should be cool'
-    
+
   when running command:
     /usr/bin/python python_out_vs_err.py

--- a/test/files/python_whitespace.expected
+++ b/test/files/python_whitespace.expected
@@ -4,13 +4,13 @@ Failure in python_whitespace.py:
     {{^}} four
 
   which failed to match line stdout:4:
-    four
+       four
 
   Context:
-    one
-    two
+        one
+        two
     three
-    four <= does not match '{{^}} four'
-    
+       four <= does not match '{{^}} four'
+
   when running command:
     /usr/bin/python python_whitespace.py


### PR DESCRIPTION
One of the issues with our current output is that it only handles the *first* mismatch, and it won't figure out if there's a line *missing*, so e.g. if the test output is

```
1
3
4
5
```

and we have CHECKs for `1`, `2`, `3`, `4` and `5`, it will complain that "3" does not match "2".

This isn't *wrong*, but it's quite misleading, and you really need to pay attention.

This PR changes the output so that it basically runs a `diff` on the lines and CHECKs. The trick is that we match the checks before, and for every CHECK that does we add the matched string, for every that didn't we add the literal CHECK.

Then we use python's difflib.SequenceMatcher to get a diff, and we print that.

The header is still just the first error, but that's also probably the most important, so it's okay.

This replaces the before/after context, because we now always do a hard-coded 3 lines of context around every diff point, so the information is already in there.

Some example output:

![Screenshot_20201116_105356](https://user-images.githubusercontent.com/5185367/99238921-a21c4100-27fa-11eb-9d1c-a321966186ca.png)

I'd like some feedback on the output, but do note that I'm trying to not make colors mandatory (in particular because Github Actions doesn't show them!), so this should still be readable without.