### PR TITLE
Skip tests that return 125

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,16 @@ $stderr.puts "this goes to stderr"
 # CHECKERR: this goes to stderr
 ```
 
+To skip tests, littlecheck provides the `# REQUIRES` directive. Anything given there will be run as a shell command (with /bin/sh, with the substitutions applied), and if any REQUIRES returns non-zero the script will be skipped:
+
+```shell
+# RUN: /bin/sh %s
+# Only run this test on macOS:
+# REQUIRES: test $(uname) = Darwin
+# Only run it if git is installed
+# REQUIRES: command -v git
+```
+
 # Integrating littlecheck
 
 To integrate littlecheck into your project, simply copy the file `littlecheck/littlecheck.py` into the appropriate place in your source tree. No other files are required.

--- a/littlecheck/littlecheck.py
+++ b/littlecheck/littlecheck.py
@@ -358,6 +358,20 @@ def perform_substitution(input_str, subs):
     return re.sub(r"%(%|[a-zA-Z0-9_-]+)", subber, input_str)
 
 
+def runproc(cmd):
+    """ Wrapper around subprocess.Popen to save typing """
+    PIPE = subprocess.PIPE
+    proc = subprocess.Popen(
+        cmd,
+        stdin=PIPE,
+        stdout=PIPE,
+        stderr=PIPE,
+        shell=True,
+        close_fds=True,  # For Python 2.6 as shipped on RHEL 6
+    )
+    return proc
+
+
 class TestRun(object):
     def __init__(self, name, runcmd, checker, subs, config):
         self.name = name
@@ -443,14 +457,7 @@ class TestRun(object):
         PIPE = subprocess.PIPE
         if self.config.verbose:
             print(self.subbed_command)
-        proc = subprocess.Popen(
-            self.subbed_command,
-            stdin=PIPE,
-            stdout=PIPE,
-            stderr=PIPE,
-            shell=True,
-            close_fds=True,  # For Python 2.6 as shipped on RHEL 6
-        )
+        proc = runproc(self.subbed_command)
         stdout, stderr = proc.communicate()
         # HACK: This is quite cheesy: POSIX specifies that sh should return 127 for a missing command.
         # Technically it's also possible to return it in other conditions.

--- a/test/files/no_skip.expected
+++ b/test/files/no_skip.expected
@@ -1,0 +1,13 @@
+Failure in no_skip.py:
+
+  The CHECK on line 6 wants:
+    This should never be compared
+
+  which failed to match line stdout:1:
+    Oh, but it is!
+
+  Context:
+    Oh, but it is! <= does not match CHECK 'This should never be compared' on line 6
+
+  when running command:
+    /usr/bin/python no_skip.py

--- a/test/files/no_skip.py
+++ b/test/files/no_skip.py
@@ -1,0 +1,6 @@
+#!/usr/bin/python
+# Any system should have an sh capable of `command -v`
+# REQUIRES: command -v sh
+
+print("Oh, but it is!")
+# CHECK: This should never be compared

--- a/test/files/shell_skip.py
+++ b/test/files/shell_skip.py
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+exit 125
+
+# CHECK: This should never be compared
+# CHECKERR: Neither should this

--- a/test/files/shell_skip.py
+++ b/test/files/shell_skip.py
@@ -1,6 +1,5 @@
 #!/bin/sh
-
-exit 125
+# REQUIRES: false
 
 # CHECK: This should never be compared
 # CHECKERR: Neither should this

--- a/test/files/skip.py
+++ b/test/files/skip.py
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/python
 # REQUIRES: false
 
 # CHECK: This should never be compared

--- a/test/test_littlecheck.py
+++ b/test/test_littlecheck.py
@@ -18,7 +18,7 @@ class LittlecheckTest(unittest.TestCase):
            The input file is the name with .py extension, the expected
            output of littlecheck is the name with .expected extension.
         """
-        test_path = name + ".py"
+        test_path = name + ".py" if not "." in name else name
         expected_output_path = name + ".expected"
         subs = {"%": "%", "s": test_path}
         conf = littlecheck.Config()
@@ -74,4 +74,7 @@ class LittlecheckTest(unittest.TestCase):
         self.do_1_path_test("python_doublereplace")
 
     def test_skip(self):
-        self.do_1_path_test("shell_skip", skip=True)
+        self.do_1_path_test("skip", skip=True)
+
+    def test_require_succeeds(self):
+        self.do_1_path_test("no_skip", skip=False)

--- a/test/test_littlecheck.py
+++ b/test/test_littlecheck.py
@@ -13,7 +13,7 @@ class LittlecheckTest(unittest.TestCase):
         test_dir = os.path.dirname(os.path.abspath(__file__))
         os.chdir(os.path.join(test_dir, "files"))
 
-    def do_1_path_test(self, name):
+    def do_1_path_test(self, name, skip=False):
         """ Run a single test. The name is the test name.
            The input file is the name with .py extension, the expected
            output of littlecheck is the name with .expected extension.
@@ -29,7 +29,10 @@ class LittlecheckTest(unittest.TestCase):
             expect_text = fd.read().strip()
             expect_success = not expect_text
             self.assertEqual(failures_message, expect_text)
-            self.assertEqual(success, expect_success)
+            if skip:
+                self.assertEqual(success, littlecheck.SKIP)
+            else:
+                self.assertEqual(success, expect_success)
 
     def test_py_ok(self):
         self.do_1_path_test("python_ok")
@@ -71,4 +74,4 @@ class LittlecheckTest(unittest.TestCase):
         self.do_1_path_test("python_doublereplace")
 
     def test_skip(self):
-        self.do_1_path_test("shell_skip")
+        self.do_1_path_test("shell_skip", skip=True)

--- a/test/test_littlecheck.py
+++ b/test/test_littlecheck.py
@@ -69,3 +69,6 @@ class LittlecheckTest(unittest.TestCase):
 
     def test_py_replace(self):
         self.do_1_path_test("python_doublereplace")
+
+    def test_skip(self):
+        self.do_1_path_test("shell_skip")


### PR DESCRIPTION
Just like `git bisect run` does.

This allows making tests that don't run in all cases.

Specifically what I have in mind is a test to fish that tests `git`,
but that can only work if `git` is installed, and we don't want to
fail it if it doesn't.

The alternative is to fake *all* of the output, which requires
duplicating all of the output somewhere.