### PR TITLE
Remove Unused `import`

### DIFF
--- a/littlecheck/littlecheck.py
+++ b/littlecheck/littlecheck.py
@@ -6,7 +6,6 @@ from __future__ import unicode_literals
 from __future__ import print_function
 
 import argparse
-from collections import deque
 import datetime
 import io
 import re


### PR DESCRIPTION
I removed the unused import according to a recommendation from LGTM (https://lgtm.com/projects/g/ridiculousfish/littlecheck/snapshot/239b0a6d437787ccbf5d6bfc7e7b0dd09e0e5176/files/littlecheck/littlecheck.py?sort=name&dir=ASC&mode=heatmap)

PS: I tried to fix this downstream at first (https://github.com/fish-shell/fish-shell/pull/7849), but am fixing it here now.