### PR TITLE
add support for pip install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,20 @@
+[project]
+name = "littlecheck"
+description = "littlecheck is a tool for testing command line tools"
+version = "0.1.0"
+readme = "README.md"
+authors = [{ name = "ridiculousfish" }]
+requires-python = ">=2.7"
+urls.Homepage = "https://github.com/ridiculousfish/littlecheck"
+classifiers = [
+    "Programming Language :: Python :: 2",
+    "Programming Language :: Python :: 3",
+    "License :: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication",
+]
+
+[project.scripts]
+littlecheck = "littlecheck.littlecheck:main"
+
+[build-system]
+requires = ["flit_core>=3.4"]
+build-backend = "flit_core.buildapi"


### PR DESCRIPTION
Fixes #10

This add a [`pyproject.toml`](https://pip.pypa.io/en/stable/reference/build-system/pyproject-toml/) file (the successor to `setup.py`, favoring static metadata and allowing different "backends" beyond `setuptools`) so users can `pip install` it:

```console
$ python3 -m venv .venv
$ .venv/bin/pip install git+https://github.com/branchvincent/littlecheck@pyproject
$ .venv/bin/littlecheck --help
usage: littlecheck [-h] [-s SUBSTITUTE] [-p] [--force-color] file [file ...]

littlecheck: command line tool tester.
...
```

As for the `build-backend`, I've chosen `flit_core` from the [packaging guide](https://packaging.python.org/en/latest/tutorials/packaging-projects/#choosing-build-backend) because it is very simple and doesn't require custom configuration (unlike `setuptools`)