### PR TITLE
Add workflow to publish to PyPI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,20 @@
+name: Release
+
+on:
+  push:
+    tags: ["*"]
+
+jobs:
+  pypi:
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/littlecheck
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v5
+      - name: Build distribution
+        run: pipx run build
+      - name: Publish
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
This is a (delayed) follow up to #13 to start publishing littlecheck to PyPI

This simple workflow is triggered on any new git tag. You just need to register this workflow with PyPI [here](https://pypi.org/manage/account/publishing/) (see [this guide](https://docs.pypi.org/trusted-publishers/creating-a-project-through-oidc/) for more info).
